### PR TITLE
Use mirego.com email domain instead of hashrocket

### DIFF
--- a/lib/tilex_web/controllers/auth_controller.ex
+++ b/lib/tilex_web/controllers/auth_controller.ex
@@ -35,7 +35,7 @@ defmodule TilexWeb.AuthController do
     email = Map.get(info, :email)
     name  = Developer.format_username(Map.get(info, :name))
 
-    case String.match?(email, ~r/@hashrocket.com$/) do
+    case String.match?(email, ~r/@mirego.com$/) do
       true ->
         attrs = %{
           email: email,


### PR DESCRIPTION
I was wondering why I couldn't log in the newly deployed instance of TIL. Here's why…